### PR TITLE
Fixed compilation on Linux

### DIFF
--- a/Marlin/src/lcd/rts/e3s1pro/lcd_rts.cpp
+++ b/Marlin/src/lcd/rts/e3s1pro/lcd_rts.cpp
@@ -17,7 +17,7 @@
 //#define LCD_RTS_DEBUG_PRINTTIME
 //#define LCD_RTS_DEBUG_LEVELING
 
-#include <Wstring.h>
+#include <WString.h>
 #include <stdio.h>
 #include <string.h>
 //#include <Arduino.h>

--- a/Marlin/src/lcd/rts/e3s1pro/lcd_rts_laser.cpp
+++ b/Marlin/src/lcd/rts/e3s1pro/lcd_rts_laser.cpp
@@ -1,4 +1,4 @@
-#include <Wstring.h>
+#include <WString.h>
 #include <stdio.h>
 #include <string.h>
 #include <Arduino.h>

--- a/Marlin/src/lcd/rts/e3s1pro/preview.cpp
+++ b/Marlin/src/lcd/rts/e3s1pro/preview.cpp
@@ -1,7 +1,7 @@
 #include "stdio.h"
 #include <stdio.h>
-#include <arduino.h>
-#include <wstring.h>
+#include <Arduino.h>
+#include <WString.h>
 #include "lcd_rts.h"
 #include "../../../inc/MarlinConfig.h"
 #include "../../../sd/cardreader.h"


### PR DESCRIPTION
Some files include improperly named headers (wrong case), that is fatal for compilation on a case-sensitive file system (e.g. on Linux).

Not sure what target branch should be, please select more appropriate one or cherry-pick the patch, if necessary.

Fixes https://github.com/ThomasToka/MarlinFirmware/issues/61
